### PR TITLE
Modify priority and reader configurations

### DIFF
--- a/application-default.properties
+++ b/application-default.properties
@@ -372,14 +372,14 @@ mosip.registration.gps_device_enable_flag=n
 ## 1. 'exception' : it will throw exception.
 ## 2. 'defaultPriority' : use default priority packetmanager.default.priority.
 packetmanager.default.read.strategy=defaultPriority
-packetmanager.default.priority=source:REGISTRATION_CLIENT\/process:BIOMETRIC_CORRECTION|NEW|RENEWAL|UPDATE|FIRSTID|LOST,source:RESIDENT\/process:ACTIVATED|DEACTIVATED|RES_UPDATE|RES_REPRINT,source:OPENCRVS\/process:OPENCRVS_NEW,source:DATAMIGRATOR\/process:MIGRATOR
+packetmanager.default.priority=source:REGISTRATION_CLIENT\/process:BIOMETRIC_CORRECTION|DEACTIVATE|NEW|RENEWAL|UPDATE|FIRSTID|LOST,source:RESIDENT\/process:ACTIVATED|DEACTIVATED|RES_UPDATE|RES_REPRINT,source:OPENCRVS\/process:OPENCRVS_NEW,source:DATAMIGRATOR\/process:MIGRATOR
 packetmanager.name.source={default:'REGISTRATION_CLIENT',resident:'RESIDENT',opencrvs:'OPENCRVS'}
 packetmanager.packet.signature.disable-verification=true
 mosip.commons.packetnames=id,evidence,optional
-provider.packetreader.mosip=source:REGISTRATION_CLIENT|DATAMIGRATOR,process:NEW|RENEWAL|UPDATE|FIRSTID|LOST|BIOMETRIC_CORRECTION|MVS_DOC|MVS_DEMOGRAPHIC|MIGRATOR,classname:io.mosip.commons.packet.impl.PacketReaderImpl
+provider.packetreader.mosip=source:REGISTRATION_CLIENT|DATAMIGRATOR,process:NEW|RENEWAL|UPDATE|FIRSTID|LOST|BIOMETRIC_CORRECTION|DEACTIVATE|MVS_DOC|MVS_DEMOGRAPHIC|MIGRATOR,classname:io.mosip.commons.packet.impl.PacketReaderImpl
 provider.packetreader.resident=source:RESIDENT,process:ACTIVATED|DEACTIVATED|RES_UPDATE|LOST|RES_REPRINT,classname:io.mosip.commons.packet.impl.PacketReaderImpl
 provider.packetreader.opencrvs=source:OPENCRVS,process:OPENCRVS_NEW,classname:io.mosip.commons.packet.impl.PacketReaderImpl
-provider.packetwriter.mosip=source:REGISTRATION_CLIENT|DATAMIGRATOR,process:NEW|RENEWAL|UPDATE|FIRSTID|LOST|BIOMETRIC_CORRECTION|MVS_DOC|MVS_DEMOGRAPHIC|MIGRATOR,classname:io.mosip.commons.packet.impl.PacketWriterImpl
+provider.packetwriter.mosip=source:REGISTRATION_CLIENT|DATAMIGRATOR,process:NEW|RENEWAL|UPDATE|FIRSTID|LOST|BIOMETRIC_CORRECTION|DEACTIVATE|MVS_DOC|MVS_DEMOGRAPHIC|MIGRATOR,classname:io.mosip.commons.packet.impl.PacketWriterImpl
 provider.packetwriter.resident=source:RESIDENT,process:ACTIVATED|DEACTIVATED|RES_UPDATE|LOST|RES_REPRINT,classname:io.mosip.commons.packet.impl.PacketWriterImpl
 provider.packetwriter.opencrvs=source:OPENCRVS,process:OPENCRVS_NEW,classname:io.mosip.commons.packet.impl.PacketWriterImpl
 objectstore.adapter.name=S3Adapter


### PR DESCRIPTION
Updated packetmanager.default.priority and provider.packetreader.mosip to include 'DEACTIVATE' process.