### PR TITLE
Update allowed update fields for lost UIN

### DIFF
--- a/registration-processor-default.properties
+++ b/registration-processor-default.properties
@@ -1079,7 +1079,7 @@ mosip.regproc.landing.zone.inital.delay.millisecs=300000
 registration.processor.lostrid.max.registrationid=5
 mosip.registration.processor.lostrid.max-registration-date-filter-interval=30
 ##Ability to update contact information as part of LOST UIN
-uingenerator.lost.packet.allowed.update.fields=phone,email,permanentAddress,userServiceType
+uingenerator.lost.packet.allowed.update.fields=phone,email,permanentAddress
 logging.level.org.apache.activemq.ActiveMQConnectionFactory=DEBUG
 
 ##timeout in milliseconds for health check registrer


### PR DESCRIPTION
Removed 'userServiceType' from allowed update fields for lost UIN.