### PR TITLE
Update online verification partner IDs

### DIFF
--- a/id-repository-default.properties
+++ b/id-repository-default.properties
@@ -504,4 +504,4 @@ mosip.kernel.http.plain.restTemplate.max-connection-per-route=100
 mosip.kernel.http.plain.restTemplate.total-max-connections=700
 
 mosip.role.idrepo.identity.getdraftUIN=RESIDENT,ID_REPOSITORY
-online-verification-partner-ids=mpartner-default-auth,mpartner-default-mvs,mpartner-default-print
+online-verification-partner-ids=mpartner-default-auth,mpartner-default-print


### PR DESCRIPTION
Removed 'mpartner-default-mvs' from online verification partner IDs.